### PR TITLE
poetry-python: Refactor tox setup

### DIFF
--- a/managetemplates/tests/test_poetry_python.py
+++ b/managetemplates/tests/test_poetry_python.py
@@ -54,5 +54,7 @@ class PoetryPythonTemplateTestCase(BaseTestCase):
 
         subprocess.check_call(['make', 'lint'], cwd=pkg_path)
 
-        output = test_project.check_output('make', 'test')
+        output = test_project.check_output('make', 'tox')
+        self.assert_in('poetry install', output)
+        self.assert_in('make test', output)
         self.assert_in('Ran 4 tests', output)

--- a/poetry-python/{{cookiecutter.package_name}}/pyproject.toml
+++ b/poetry-python/{{cookiecutter.package_name}}/pyproject.toml
@@ -90,7 +90,9 @@ skip_missing_interpreters = True
 
 [testenv]
 passenv = *
-whitelist_externals = make
+allowlist_externals = make
+commands_pre =
+    make install
 commands =
     make test
 """


### PR DESCRIPTION
Use "Usecase #3" https://python-poetry.org/docs/faq/#is-tox-supported """
tox will not do any install. Poetry installs all the dependencies and the current package an editable mode. Thus, tests are running against the local files and not the built and installed package.
"""

Must call poetry via `make` to cover the make file, too.