### PR TITLE
Fix github actions

### DIFF
--- a/managetemplates/utilities/test_project_utils.py
+++ b/managetemplates/utilities/test_project_utils.py
@@ -25,7 +25,7 @@ class TestProject:
     ) -> str:
         kwargs.setdefault('text', True)
 
-        env = dict(PATH=os.environ['PATH'])  # Use a clean environment
+        env = dict(os.environ)
         if extra_env:
             env.update(extra_env)
 


### PR DESCRIPTION
Github API has a rate limit.

A `assert_project_version()` that fetch the project tags from Github API will ran into this limit, e.g.:
https://github.com/jedie/cookiecutter_templates/actions/runs/3909278543/jobs/6680193461#step:8:145

Pass all environment variables to the test code, so that a `GITHUB_ACTION` exists and the test can be skipped.